### PR TITLE
Fix: use PIL's frombytes(), fromstring() has been deprecated

### DIFF
--- a/evic/cli.py
+++ b/evic/cli.py
@@ -524,7 +524,7 @@ def screenshot(output):
     data = dev.read_screen()
 
     # create the image from screen data
-    im = Image.fromstring("1",(64,128),bytes(data))
+    im = Image.frombytes("1",(64,128),bytes(data))
 
     # Write the image to the file
     with handle_exceptions(IOError):


### PR DESCRIPTION
Currently, using the most up-to-date python & libs, PIL throws this when attempting to take a screenshot using `evic-usb screenshot -o filename.png`:  
`NotImplementedError: fromstring() has been removed. Please call frombytes() instead.`

The proposed fix is to use frombytes() instead.